### PR TITLE
Fail the entire release with exit code 1 instead of breaking out of the loop with exit code 0

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,7 +11,7 @@ stargate_version=$1
 
 for script in $(find . -type f -name 'build.sh'); do
     echo "Executing $script"
-    bash "$script" $stargate_version || break
+    bash "$script" $stargate_version
 
     echo ""
 done


### PR DESCRIPTION
When iterating over all our images to build (one for each cassandra version), it's possible for any of the `build.sh` processes to fail; before they would `break` out of the loop, but that causes the release.sh process to return an exit code of 0, which means execution just continues.  We would way rather have the whole build fail, equivalent to what we had before except the exit code is 1

In the future maybe this should be done in two steps to make it atomic, such as - 1) build all three images, ensure all are exit code 0, then 2) push all three to docker hub...but this is fine for now