### PR TITLE
Revert changes to use a common builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM openjdk:8u252-slim
-
-RUN apt update -qq \
-    && apt install curl unzip iproute2 libaio1 -y \
-    && apt autoremove --yes \
-    && apt clean all \
-    && rm -rf /var/lib/apt/lists/*

--- a/cassandra-3.11/Dockerfile
+++ b/cassandra-3.11/Dockerfile
@@ -1,6 +1,12 @@
-FROM stargate-builder as builder
+FROM openjdk:8u252-slim
 
 ARG STARGATE_VERSION=v1.0.1
+
+RUN apt update -qq \
+    && apt install curl unzip iproute2 libaio1 -y \
+    && apt autoremove --yes \
+    && apt clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \

--- a/cassandra-4.0/Dockerfile
+++ b/cassandra-4.0/Dockerfile
@@ -1,6 +1,12 @@
-FROM stargate-builder as builder
+FROM openjdk:8u252-slim
 
 ARG STARGATE_VERSION=v1.0.1
+
+RUN apt update -qq \
+    && apt install curl unzip iproute2 libaio1 -y \
+    && apt autoremove --yes \
+    && apt clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \

--- a/dse-6.8/Dockerfile
+++ b/dse-6.8/Dockerfile
@@ -1,12 +1,13 @@
 FROM openjdk:8u252-slim
 
+ARG STARGATE_VERSION=v1.0.1
+
 RUN apt update -qq \
     && apt install curl unzip iproute2 libaio1 -y \
     && apt autoremove --yes \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
 
-ARG STARGATE_VERSION=v1.0.1
 RUN curl -sL https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \
     && unzip stargate-jars "*/persistence-api*" \

--- a/dse-6.8/Dockerfile
+++ b/dse-6.8/Dockerfile
@@ -1,4 +1,10 @@
-FROM stargate-builder as builder
+FROM openjdk:8u252-slim
+
+RUN apt update -qq \
+    && apt install curl unzip iproute2 libaio1 -y \
+    && apt autoremove --yes \
+    && apt clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG STARGATE_VERSION=v1.0.1
 RUN curl -sL https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \


### PR DESCRIPTION
Turns out that buildx does not play nice with local images

https://stackoverflow.com/a/62594035/13078421

So rather than messing with the driver used or pushing to a remote repo just reverting this until we have a need that's worth the effort.