### PR TITLE
Bump to 1.0.2

### DIFF
--- a/cassandra-3.11/Dockerfile
+++ b/cassandra-3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u252-slim
 
-ARG STARGATE_VERSION=v1.0.1
+ARG STARGATE_VERSION=v1.0.2
 
 RUN apt update -qq \
     && apt install curl unzip iproute2 libaio1 -y \

--- a/cassandra-4.0/Dockerfile
+++ b/cassandra-4.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u252-slim
 
-ARG STARGATE_VERSION=v1.0.1
+ARG STARGATE_VERSION=v1.0.2
 
 RUN apt update -qq \
     && apt install curl unzip iproute2 libaio1 -y \

--- a/dse-6.8/Dockerfile
+++ b/dse-6.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u252-slim
 
-ARG STARGATE_VERSION=v1.0.1
+ARG STARGATE_VERSION=v1.0.2
 
 RUN apt update -qq \
     && apt install curl unzip iproute2 libaio1 -y \


### PR DESCRIPTION
stargate is already tagged at 1.0.2 but no docker image was made, this will square that up