### PR TITLE
Add start scripts for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 - [with Apache Cassandra 3.11](./examples/cassandra-3.11/docker-compose.yml)
 - [with Apache Cassandra 4.0](./examples/cassandra-4.0/docker-compose.yml)
 - [with DSE 6.8](./examples/dse-6.8/docker-compose.yml)
+- [add Apache Zeppelin to any environment](./examples/add_zeppelin)
+- [with Apache Cassanda 3.11, Prometheus, and Grafana](./examples/stargate-prometheus-grafana/docker-compose.yml)
 
+Each example also has a `start_***.sh` to aid starting the docker-compose environment.
 
 ### Configuration
 

--- a/examples/add_zeppelin/README.md
+++ b/examples/add_zeppelin/README.md
@@ -1,0 +1,32 @@
+To add zeppelin to any multi-container environment, add the following information:
+
+To `docker-compose.yaml`:
+
+  zeppelin:
+    image: apache/zeppelin:${ZEPPTAG}
+    #container_name: zeppelin
+    depends_on:
+      - backend-1
+    networks:
+      - backend
+    ports:
+      - 10002:8080
+
+To the `start_***.sh` at the top with the other exported variables:
+
+export ZEPPTAG=0.9.0
+
+and after the last line in `start_***.sh`:
+
+# Wait until stargate is up before bringing up zeppelin
+
+echo ""
+echo "Waiting for stargate to start up..."
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/health)" != "200" ]]; do
+    printf '.'
+    sleep 5
+done
+
+# Bring up zeppelin
+
+docker-compose up -d zeppelin

--- a/examples/add_zeppelin/README.md
+++ b/examples/add_zeppelin/README.md
@@ -22,15 +22,6 @@ export ZEPPTAG=0.9.0
 and after the last line in `start_***.sh`:
 
 ```
-# Wait until stargate is up before bringing up zeppelin
-
-echo ""
-echo "Waiting for stargate to start up..."
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/health)" != "200" ]]; do
-    printf '.'
-    sleep 5
-done
-
 # Bring up zeppelin
 
 docker-compose up -d zeppelin

--- a/examples/add_zeppelin/README.md
+++ b/examples/add_zeppelin/README.md
@@ -2,6 +2,7 @@ To add zeppelin to any multi-container environment, add the following informatio
 
 To `docker-compose.yaml`:
 
+```
   zeppelin:
     image: apache/zeppelin:${ZEPPTAG}
     #container_name: zeppelin
@@ -11,13 +12,17 @@ To `docker-compose.yaml`:
       - backend
     ports:
       - 10002:8080
+```
 
 To the `start_***.sh` at the top with the other exported variables:
 
+```
 export ZEPPTAG=0.9.0
+```
 
 and after the last line in `start_***.sh`:
 
+```
 # Wait until stargate is up before bringing up zeppelin
 
 echo ""
@@ -30,3 +35,4 @@ done
 # Bring up zeppelin
 
 docker-compose up -d zeppelin
+```

--- a/examples/add_zeppelin/README.md
+++ b/examples/add_zeppelin/README.md
@@ -5,7 +5,6 @@ To `docker-compose.yaml`:
 ```
   zeppelin:
     image: apache/zeppelin:${ZEPPTAG}
-    #container_name: zeppelin
     depends_on:
       - backend-1
     networks:

--- a/examples/cassandra-3.11/.env
+++ b/examples/cassandra-3.11/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cass3x-stargate

--- a/examples/cassandra-3.11/README.md
+++ b/examples/cassandra-3.11/README.md
@@ -1,7 +1,10 @@
 Three files to use docker-compose to start a small Cassandra 3.x cluster and one Stargate node:
 
-docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+* docker-compose.yaml: File that contains all parameters for starting multi-container environment.
 
-start_cass3x.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+* start_cass3x.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
 
-.env: Project name for container naming
+* .env: Project name for container naming
+
+**Be aware that running more than one of these multi-container environments on one host may require 
+changing the port mapping to be changed to avoid conflicts on the host machine.**

--- a/examples/cassandra-3.11/README.md
+++ b/examples/cassandra-3.11/README.md
@@ -1,0 +1,7 @@
+Three files to use docker-compose to start a small Cassandra 3.x cluster and one Stargate node:
+
+docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+
+start_cass3x.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+
+.env: Project name for container naming

--- a/examples/cassandra-3.11/docker-compose.yml
+++ b/examples/cassandra-3.11/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - 8081:8081
       - 8082:8082
       - 8084:8084
-      - 8085:8085
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"

--- a/examples/cassandra-3.11/docker-compose.yml
+++ b/examples/cassandra-3.11/docker-compose.yml
@@ -2,8 +2,8 @@ version: '2'
 
 services:
   backend-1:
-    image: cassandra:4.0
-    container_name: backend-1
+    image: cassandra:${CASSTAG}
+    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -13,10 +13,10 @@ services:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
       - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   backend-2:
-    image: cassandra:4.0
-    container_name: backend-2
+    image: cassandra:${CASSTAG}
+    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -26,10 +26,10 @@ services:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
       - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   backend-3:
-    image: cassandra:4.0
-    container_name: backend-3
+    image: cassandra:${CASSTAG}
+    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -39,10 +39,10 @@ services:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
       - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   stargate:
-    image: stargateio/stargate-4_0:v1.0.0
-    container_name: stargate
+    image: stargateio/stargate-3_11:${SGTAG}
+    #container_name: stargate
     depends_on: 
       - backend-1
     networks:
@@ -53,11 +53,12 @@ services:
       - 8081:8081
       - 8082:8082
       - 8084:8084
+      - 8085:8085
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
-      - CLUSTER_NAME=backend
-      - CLUSTER_VERSION=4.0
+      - CLUSTER_NAME=c3-${CASSTAG}-cluster
+      - CLUSTER_VERSION=3.11
       - SEED=backend-1
       - RACK_NAME=rack1
       - DATACENTER_NAME=dc1

--- a/examples/cassandra-3.11/docker-compose.yml
+++ b/examples/cassandra-3.11/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2'
 services:
   backend-1:
     image: cassandra:${CASSTAG}
-    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -16,7 +15,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   backend-2:
     image: cassandra:${CASSTAG}
-    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -29,7 +27,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   backend-3:
     image: cassandra:${CASSTAG}
-    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -42,7 +39,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c3-${CASSTAG}-cluster
   stargate:
     image: stargateio/stargate-3_11:${SGTAG}
-    #container_name: stargate
     depends_on: 
       - backend-1
     networks:

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -14,12 +14,12 @@ docker-compose up -d backend-1
 # Bring up the 2nd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-2
-#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-3
-#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate
 

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -18,7 +18,7 @@ docker-compose up -f $COMPOSE_FILE -d backend-2
 
 # Bring up the 3rd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-3
+docker-compose up -f $COMPOSE_FILE -d backend-3
 (docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -24,3 +24,12 @@ docker-compose up -d backend-1
 # Bring up the stargate
 
 docker-compose up -d stargate
+
+# Wait until stargate is up before bringing up zeppelin
+
+echo ""
+echo "Waiting for stargate to start up..."
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/health)" != "200" ]]; do
+    printf '.'
+    sleep 5
+done

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+export CASSTAG=3.11.8
+export SGTAG=v1.0.7
+
+# Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
+
+docker-compose up -d backend-1
+
+# Wait until the seed node is up before bringing up more nodes
+
+(docker-compose logs -f backend-1 &) | grep -q "Created default superuser role"
+
+# Bring up the 2nd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-2
+#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+
+# Bring up the 3rd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-3
+#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+
+# Bring up the stargate
+
+docker-compose up -d stargate

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -13,7 +13,7 @@ docker-compose up -d backend-1
 
 # Bring up the 2nd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-2
+docker-compose up -f $COMPOSE_FILE -d backend-2
 (docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node

--- a/examples/cassandra-4.0/.env
+++ b/examples/cassandra-4.0/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cass40-stargate

--- a/examples/cassandra-4.0/README.md
+++ b/examples/cassandra-4.0/README.md
@@ -1,7 +1,10 @@
 Three files to use docker-compose to start a small Cassandra 4.0 cluster and one Stargate node:
 
-docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+* docker-compose.yaml: File that contains all parameters for starting multi-container environment.
 
-start_cass40.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+* start_cass40.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
 
-.env: Project name for container naming
+* .env: Project name for container naming
+
+**Be aware that running more than one of these multi-container environments on one host may require
+changing the port mapping to be changed to avoid conflicts on the host machine.**

--- a/examples/cassandra-4.0/README.md
+++ b/examples/cassandra-4.0/README.md
@@ -1,0 +1,7 @@
+Three files to use docker-compose to start a small Cassandra 4.0 cluster and one Stargate node:
+
+docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+
+start_cass40.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+
+.env: Project name for container naming

--- a/examples/cassandra-4.0/docker-compose.yml
+++ b/examples/cassandra-4.0/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - 8081:8081
       - 8082:8082
       - 8084:8084
-      - 8085:8085
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"

--- a/examples/cassandra-4.0/docker-compose.yml
+++ b/examples/cassandra-4.0/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     environment:
       - JAVA_OPTS="-Xmx2G"
       - CLUSTER_NAME=c4-${CASSTAG}-cluster
-      - CLUSTER_VERSION=3.11
+      - CLUSTER_VERSION=4.0
       - SEED=backend-1
       - RACK_NAME=rack1
       - DATACENTER_NAME=dc1

--- a/examples/cassandra-4.0/docker-compose.yml
+++ b/examples/cassandra-4.0/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2'
 services:
   backend-1:
     image: cassandra:${CASSTAG}
-    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -16,7 +15,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   backend-2:
     image: cassandra:${CASSTAG}
-    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -29,7 +27,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   backend-3:
     image: cassandra:${CASSTAG}
-    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -42,7 +39,6 @@ services:
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   stargate:
     image: stargateio/stargate-3_11:${SGTAG}
-    #container_name: stargate
     depends_on: 
       - backend-1
     networks:

--- a/examples/cassandra-4.0/docker-compose.yml
+++ b/examples/cassandra-4.0/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - CASSANDRA_SEEDS=backend-1
       - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   stargate:
-    image: stargateio/stargate-3_11:${SGTAG}
+    image: stargateio/stargate-4_0:${SGTAG}
     depends_on: 
       - backend-1
     networks:

--- a/examples/cassandra-4.0/docker-compose.yml
+++ b/examples/cassandra-4.0/docker-compose.yml
@@ -2,8 +2,8 @@ version: '2'
 
 services:
   backend-1:
-    image: datastax/dse-server:6.8.7
-    container_name: backend-1
+    image: cassandra:${CASSTAG}
+    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -12,14 +12,11 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - SEEDS=backend-1
-      - CLUSTER_NAME=backend
-      - DC=dc1
-      - RACK=rack1
-      - DS_LICENSE=accept
+      - CASSANDRA_SEEDS=backend-1
+      - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   backend-2:
-    image: datastax/dse-server:6.8.7
-    container_name: backend-2
+    image: cassandra:${CASSTAG}
+    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -28,14 +25,11 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - SEEDS=backend-1
-      - CLUSTER_NAME=backend
-      - DC=dc1
-      - RACK=rack1
-      - DS_LICENSE=accept
+      - CASSANDRA_SEEDS=backend-1
+      - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   backend-3:
-    image: datastax/dse-server:6.8.7
-    container_name: backend-3
+    image: cassandra:${CASSTAG}
+    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -44,13 +38,11 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - SEEDS=backend-1
-      - CLUSTER_NAME=backend
-      - DC=dc1
-      - DS_LICENSE=accept
+      - CASSANDRA_SEEDS=backend-1
+      - CASSANDRA_CLUSTER_NAME=c4-${CASSTAG}-cluster
   stargate:
-    image: stargateio/stargate-dse-68:v1.0.0
-    container_name: stargate
+    image: stargateio/stargate-3_11:${SGTAG}
+    #container_name: stargate
     depends_on: 
       - backend-1
     networks:
@@ -61,12 +53,12 @@ services:
       - 8081:8081
       - 8082:8082
       - 8084:8084
+      - 8085:8085
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
-      - CLUSTER_NAME=backend
-      - CLUSTER_VERSION=6.8
-      - DSE=1
+      - CLUSTER_NAME=c4-${CASSTAG}-cluster
+      - CLUSTER_VERSION=3.11
       - SEED=backend-1
       - RACK_NAME=rack1
       - DATACENTER_NAME=dc1

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -14,12 +14,12 @@ docker-compose up -d backend-1
 # Bring up the 2nd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-2
-#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-3
-#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate
 

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -18,7 +18,7 @@ docker-compose up -f $COMPOSE_FILE -d backend-2
 
 # Bring up the 3rd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-3
+docker-compose up -f $COMPOSE_FILE -d backend-3
 (docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+export CASSTAG=4.0
+export SGTAG=v1.0.7
+
+# Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
+
+docker-compose up -d backend-1
+
+# Wait until the seed node is up before bringing up more nodes
+
+(docker-compose logs -f backend-1 &) | grep -q "Created default superuser role"
+
+# Bring up the 2nd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-2
+#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+
+# Bring up the 3rd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-3
+#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+
+# Bring up the stargate
+
+docker-compose up -d stargate

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -24,3 +24,12 @@ docker-compose up -d backend-1
 # Bring up the stargate
 
 docker-compose up -d stargate
+
+# Wait until stargate is up before bringing up zeppelin
+
+echo ""
+echo "Waiting for stargate to start up..."
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/health)" != "200" ]]; do
+    printf '.'
+    sleep 5
+done

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -13,7 +13,7 @@ docker-compose up -d backend-1
 
 # Bring up the 2nd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-2
+docker-compose up -f $COMPOSE_FILE -d backend-2
 (docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node

--- a/examples/dse-6.8/.env
+++ b/examples/dse-6.8/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=dse68-stargate

--- a/examples/dse-6.8/README.md
+++ b/examples/dse-6.8/README.md
@@ -1,7 +1,10 @@
 Three files to use docker-compose to start a small DataStax Enterprise 6.8 cluster and one Stargate node:
 
-docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+* docker-compose.yaml: File that contains all parameters for starting multi-container environment.
 
-start_dse_68.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+* start_dse_68.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
 
-.env: Project name for container naming
+* .env: Project name for container naming
+
+**Be aware that running more than one of these multi-container environments on one host may require
+changing the port mapping to be changed to avoid conflicts on the host machine.**

--- a/examples/dse-6.8/README.md
+++ b/examples/dse-6.8/README.md
@@ -1,0 +1,7 @@
+Three files to use docker-compose to start a small DataStax Enterprise 6.8 cluster and one Stargate node:
+
+docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+
+start_dse_68.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+
+.env: Project name for container naming

--- a/examples/dse-6.8/docker-compose.yml
+++ b/examples/dse-6.8/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2'
 services:
   backend-1:
     image: datastax/dse-server:${DSETAG}
-    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -19,7 +18,6 @@ services:
       - DS_LICENSE=accept
   backend-2:
     image: datastax/dse-server:${DSETAG}
-    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -35,7 +33,6 @@ services:
       - DS_LICENSE=accept
   backend-3:
     image: datastax/dse-server:${DSETAG}
-    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -50,7 +47,6 @@ services:
       - DS_LICENSE=accept
   stargate:
     image: stargateio/stargate-dse-68:${SGTAG}
-    container_name: stargate
     depends_on: 
       - backend-1
     networks:

--- a/examples/dse-6.8/docker-compose.yml
+++ b/examples/dse-6.8/docker-compose.yml
@@ -2,8 +2,8 @@ version: '2'
 
 services:
   backend-1:
-    image: cassandra:3.11.8
-    container_name: backend-1
+    image: datastax/dse-server:${DSETAG}
+    #container_name: backend-1
     networks:
       - backend
     ports:
@@ -12,11 +12,14 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - SEEDS=backend-1
+      - CLUSTER_NAME=dse-${DSETAG}-cluster
+      - DC=dc1
+      - RACK=rack1
+      - DS_LICENSE=accept
   backend-2:
-    image: cassandra:3.11.8
-    container_name: backend-2
+    image: datastax/dse-server:${DSETAG}
+    #container_name: backend-2
     networks:
       - backend
     mem_limit: 2G
@@ -25,11 +28,14 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - SEEDS=backend-1
+      - CLUSTER_NAME=dse-${DSETAG}-cluster
+      - DC=dc1
+      - RACK=rack1
+      - DS_LICENSE=accept
   backend-3:
-    image: cassandra:3.11.8
-    container_name: backend-3
+    image: datastax/dse-server:${DSETAG}
+    #container_name: backend-3
     networks:
       - backend
     mem_limit: 2G
@@ -38,10 +44,12 @@ services:
     environment:
       - HEAP_NEWSIZE=128M
       - MAX_HEAP_SIZE=1024M
-      - CASSANDRA_SEEDS=backend-1
-      - CASSANDRA_CLUSTER_NAME=backend
+      - SEEDS=backend-1
+      - CLUSTER_NAME=dse-${DSETAG}-cluster
+      - DC=dc1
+      - DS_LICENSE=accept
   stargate:
-    image: stargateio/stargate-3_11:v1.0.0
+    image: stargateio/stargate-dse-68:${SGTAG}
     container_name: stargate
     depends_on: 
       - backend-1
@@ -56,8 +64,9 @@ services:
     mem_limit: 2G
     environment:
       - JAVA_OPTS="-Xmx2G"
-      - CLUSTER_NAME=backend
-      - CLUSTER_VERSION=3.11
+      - CLUSTER_NAME=dse-${DSETAG}-cluster
+      - CLUSTER_VERSION=6.8
+      - DSE=1
       - SEED=backend-1
       - RACK_NAME=rack1
       - DATACENTER_NAME=dc1

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -14,12 +14,12 @@ docker-compose up -d backend-1
 # Bring up the 2nd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-2
-#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node
 
 #docker-compose up -f $COMPOSE_FILE -d backend-3
-#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate
 

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -18,7 +18,7 @@ docker-compose up -f $COMPOSE_FILE -d backend-2
 
 # Bring up the 3rd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-3
+docker-compose up -f $COMPOSE_FILE -d backend-3
 (docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
 
 # Bring up the stargate

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -24,3 +24,12 @@ docker-compose up -d backend-1
 # Bring up the stargate
 
 docker-compose up -d stargate
+
+# Wait until stargate is up before bringing up zeppelin
+
+echo ""
+echo "Waiting for stargate to start up..."
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/health)" != "200" ]]; do
+    printf '.'
+    sleep 5
+done

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -13,7 +13,7 @@ docker-compose up -d backend-1
 
 # Bring up the 2nd C* node
 
-#docker-compose up -f $COMPOSE_FILE -d backend-2
+docker-compose up -f $COMPOSE_FILE -d backend-2
 (docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
 
 # Bring up the 3rd C* node

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+export DSETAG=6.8.9
+export SGTAG=v1.0.7
+
+# Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
+
+docker-compose up -d backend-1
+
+# Wait until the seed node is up before bringing up more nodes
+
+(docker-compose logs -f backend-1 &) | grep -q "Created default superuser role"
+
+# Bring up the 2nd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-2
+#(docker-compose logs -f backend-2 &) | grep -q "is now part of the cluster"
+
+# Bring up the 3rd C* node
+
+#docker-compose up -f $COMPOSE_FILE -d backend-3
+#(docker-compose logs -f backend-3 &) | grep -q "is now part of the cluster"
+
+# Bring up the stargate
+
+docker-compose up -d stargate

--- a/examples/stargate-prometheus-grafana/.env
+++ b/examples/stargate-prometheus-grafana/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cass3x-stargate-prometh-grafana

--- a/examples/stargate-prometheus-grafana/README.md
+++ b/examples/stargate-prometheus-grafana/README.md
@@ -1,0 +1,12 @@
+Five files to use docker-compose to start a small Cassandra 3.x cluster and one Stargate node:
+
+docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+
+start_stargate-prometheus-grafana.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+
+.env: Project name for container naming
+
+prometheus.yml: File that contains parameters for setting interactions between prometheus and stargate.
+
+cqlsh-commands.txt: Commands that can be used to run a Cassandra Query Language (CQL) shell, cqlsh, in a container
+for use with the multi-container environment.

--- a/examples/stargate-prometheus-grafana/README.md
+++ b/examples/stargate-prometheus-grafana/README.md
@@ -10,3 +10,6 @@ prometheus.yml: File that contains parameters for setting interactions between p
 
 cqlsh-commands.txt: Commands that can be used to run a Cassandra Query Language (CQL) shell, cqlsh, in a container
 for use with the multi-container environment.
+
+**Be aware that running more than one of these multi-container environments on one host may require
+changing the port mapping to be changed to avoid conflicts on the host machine.**

--- a/examples/stargate-prometheus-grafana/README.md
+++ b/examples/stargate-prometheus-grafana/README.md
@@ -1,14 +1,14 @@
 Five files to use docker-compose to start a small Cassandra 3.x cluster and one Stargate node:
 
-docker-compose.yaml: File that contains all parameters for starting multi-container environment.
+* docker-compose.yaml: File that contains all parameters for starting multi-container environment.
 
-start_stargate-prometheus-grafana.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+* start_stargate-prometheus-grafana.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
 
-.env: Project name for container naming
+* .env: Project name for container naming
 
-prometheus.yml: File that contains parameters for setting interactions between prometheus and stargate.
+* prometheus.yml: File that contains parameters for setting interactions between prometheus and stargate.
 
-cqlsh-commands.txt: Commands that can be used to run a Cassandra Query Language (CQL) shell, cqlsh, in a container
+* cqlsh-commands.txt: Commands that can be used to run a Cassandra Query Language (CQL) shell, cqlsh, in a container
 for use with the multi-container environment.
 
 **Be aware that running more than one of these multi-container environments on one host may require

--- a/examples/stargate-prometheus-grafana/prometheus.yml
+++ b/examples/stargate-prometheus-grafana/prometheus.yml
@@ -26,4 +26,4 @@ scrape_configs:
     # scheme defaults to 'http'.
 
     static_configs:
-    - targets: ['stargate:8085']
+    - targets: ['stargate:8084']

--- a/examples/stargate-prometheus-grafana/start_stargate-prometheus-grafana.sh
+++ b/examples/stargate-prometheus-grafana/start_stargate-prometheus-grafana.sh
@@ -16,6 +16,7 @@ docker-compose up -d backend-3
 
 # Bring up the stargate
 docker-compose up -d stargate
+
 # Wait until stargate is up before bringing up the metrics tools
 echo ""
 echo "Waiting for stargate to start up..."


### PR DESCRIPTION
Please add this PR after Jeff Carpenter's PR. 

I've done the following in docker-images/examples:
- Added a start_***.sh that can be used to start docker-compose in a sane fashion.
- Added some variables for the docker image tagging (declared in the shell script, used in the docker-compose.yaml script).
- Added a .env file with the COMPOSE_PROJECT_NAME, that eases running multiple docker-compose files on the same machine.
- Added a "add_zeppelin" directory that explains how to add zeppelin to any environment.
- Added a README. md to all example directories.