### PR TITLE
use Stargate v1.0.25

### DIFF
--- a/bump_stargate.sh
+++ b/bump_stargate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z ${1+x} ]; then 
+   echo "stargate version is a required argument"
+   exit 1
+fi
+
+STARGATE_VERSION=$1
+find -name "Dockerfile" -exec sed -i "s|ARG STARGATE_VERSION=.*|ARG STARGATE_VERSION=${STARGATE_VERSION}|" {} \;
+find -name "start_*.sh" -exec sed -i "s|export SGTAG=.*|export SGTAG=${STARGATE_VERSION}|" {} \;

--- a/bump_stargate.sh
+++ b/bump_stargate.sh
@@ -8,5 +8,5 @@ if [ -z ${1+x} ]; then
 fi
 
 STARGATE_VERSION=$1
-find -name "Dockerfile" -exec sed -i "s|ARG STARGATE_VERSION=.*|ARG STARGATE_VERSION=${STARGATE_VERSION}|" {} \;
-find -name "start_*.sh" -exec sed -i "s|export SGTAG=.*|export SGTAG=${STARGATE_VERSION}|" {} \;
+find . -name "Dockerfile" -exec perl -i -pe "s|ARG STARGATE_VERSION=.*|ARG STARGATE_VERSION=${STARGATE_VERSION}|" {} \;
+find . -name "start_*.sh" -exec perl -i -pe "s|export SGTAG=.*|export SGTAG=${STARGATE_VERSION}|" {} \;

--- a/cassandra-3.11/Dockerfile
+++ b/cassandra-3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u252-slim
 
-ARG STARGATE_VERSION=v1.0.24
+ARG STARGATE_VERSION=v1.0.25
 
 RUN apt update -qq \
     && apt install curl unzip iproute2 libaio1 -y \

--- a/cassandra-4.0/Dockerfile
+++ b/cassandra-4.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u252-slim
 
 
-ARG STARGATE_VERSION=v1.0.24
+ARG STARGATE_VERSION=v1.0.25
 
 
 RUN apt update -qq \

--- a/dse-6.8/Dockerfile
+++ b/dse-6.8/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u252-slim
 
 
-ARG STARGATE_VERSION=v1.0.24
+ARG STARGATE_VERSION=v1.0.25
 
 
 RUN apt update -qq \

--- a/examples/cassandra-3.11/start_cass_311.sh
+++ b/examples/cassandra-3.11/start_cass_311.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export CASSTAG=3.11.8
-export SGTAG=v1.0.24
+export SGTAG=v1.0.25
 
 # Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
 

--- a/examples/cassandra-4.0/start_cass40.sh
+++ b/examples/cassandra-4.0/start_cass40.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export CASSTAG=4.0
-export SGTAG=v1.0.24
+export SGTAG=v1.0.25
 
 # Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
 

--- a/examples/dse-6.8/start_dse_68.sh
+++ b/examples/dse-6.8/start_dse_68.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export DSETAG=6.8.9
-export SGTAG=v1.0.24
+export SGTAG=v1.0.25
 
 # Make sure backend-1, the seed node, is up before bringing up other nodes and stargate
 

--- a/examples/stargate-jwt-auth/start_jwt.sh
+++ b/examples/stargate-jwt-auth/start_jwt.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export CASSTAG=3.11.10
-export SGTAG=v1.0.7
+export SGTAG=v1.0.25
 export KCTAG=latest
 
 SG_AUTH_DIR=/Users/lorina.poland/CLONES/stargate/docker-images/examples/stargate-jwt-auth


### PR DESCRIPTION
**BLOCKED: until Stargate libs are published on the maven repository.**

Please confirm:
* I added a script to automate the version bump, and it seems it found a file that was not moved since `v1.0.7`. I guess there is no reason not to move the `start_jwt.sh` also to latest version?
* Can somebody on the MacOS try to run `./bump_stargate.sh v.1.2.3` and confirm that it's correct?