### PR TITLE
running stargate as non-root user inside docker images

### DIFF
--- a/cassandra-3.11/Dockerfile
+++ b/cassandra-3.11/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:8u292-slim
+FROM openjdk:8-slim
+
+RUN set -x \
+    && groupadd -r stargate --gid=999 \
+    && useradd -r -g stargate -d /stargate --uid=999 stargate
 
 ARG STARGATE_VERSION=v1.0.51
 
@@ -7,6 +11,9 @@ RUN apt update -qq \
     && apt autoremove --yes \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
+
+USER stargate
+WORKDIR /stargate
 
 RUN curl -L https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \

--- a/cassandra-4.0/Dockerfile
+++ b/cassandra-4.0/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:8u292-slim
+FROM openjdk:8-slim
+
+RUN set -x \
+    && groupadd -r stargate --gid=999 \
+    && useradd -r -g stargate -d /stargate --uid=999 stargate
 
 ARG STARGATE_VERSION=v1.0.51
 
@@ -7,6 +11,9 @@ RUN apt update -qq \
     && apt autoremove --yes \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
+
+USER stargate
+WORKDIR /stargate
 
 RUN curl -sL https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \

--- a/dse-6.8/Dockerfile
+++ b/dse-6.8/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:8u292-slim
+FROM openjdk:8-slim
+
+RUN set -x \
+    && groupadd -r stargate --gid=999 \
+    && useradd -r -g stargate -d /stargate --uid=999 stargate
 
 ARG STARGATE_VERSION=v1.0.51
 
@@ -7,6 +11,9 @@ RUN apt update -qq \
     && apt autoremove --yes \
     && apt clean all \
     && rm -rf /var/lib/apt/lists/*
+
+USER stargate
+WORKDIR /stargate
 
 RUN curl -sL https://github.com/stargate/stargate/releases/download/${STARGATE_VERSION}/stargate-jars.zip > stargate-jars.zip \
     && unzip stargate-jars -x "*/persistence-*" \


### PR DESCRIPTION
This PR updates the Dockerfiles for the Cassandra 3.11, Cassandra 4.0, and DSE 6.8 images to create a non-root `stargate` user to download and run stargate.

**Checklist**
- [x] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
