### PR TITLE
Change CODEOWNERS to refer to "Core" team instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mpenick @EricBorczuk @olim7t @tomekl007 @ivansenic @tatu-at-datastax @jeffreyscarpenter
+* @stargate/Core


### PR DESCRIPTION
**What this PR does**:

Change access to go via `Core` team instead of listing individuals; this to make maintenance easier.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
