### PR TITLE
deprecate C* 3.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Docker images for Stargate v1.
 Note:
 For Stargate v2, Docker images are built in the [main repository](https://github.com/stargate/stargate), with examples under the [docker-compose directory](https://github.com/stargate/stargate/tree/main/docker-compose).
 
+Warning: Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).
+
 ## docker compose
 
 [Examples directory](./examples) contains some [docker compose](https://docs.docker.com/compose/) files for stargate with different backends (3 nodes): 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker images for Stargate v1.
 Note:
 For Stargate v2, Docker images are built in the [main repository](https://github.com/stargate/stargate), with examples under the [docker-compose directory](https://github.com/stargate/stargate/tree/main/docker-compose).
 
-Warning: Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).
+Warning: Both the Stargate v1 release series and support for Cassandra 3.11 are considered deprecated. Stargate v1 will be unsupported as of the v3 release, which will not include support for Cassandra 3.11: [details](https://github.com/stargate/stargate/discussions/2242).
 
 ## docker compose
 

--- a/examples/cassandra-3.11/README.md
+++ b/examples/cassandra-3.11/README.md
@@ -1,10 +1,14 @@
-Three files to use docker-compose to start a small Cassandra 3.x cluster and one Stargate node:
+# Docker Compose scripts for Stargate with Cassandra 3.11
+
+Three files to use docker-compose to start a small Cassandra 3.11 cluster and one Stargate node:
 
 * docker-compose.yaml: File that contains all parameters for starting multi-container environment.
 
-* start_cass3x.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
+* start_cass311.sh: Shell script to start all nodes properly. Uses variables for docker image tags.
 
 * .env: Project name for container naming
 
 **Be aware that running more than one of these multi-container environments on one host may require 
 changing the port mapping to be changed to avoid conflicts on the host machine.**
+
+Warning: Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).

--- a/examples/cassandra-3.11/README.md
+++ b/examples/cassandra-3.11/README.md
@@ -11,4 +11,4 @@ Three files to use docker-compose to start a small Cassandra 3.11 cluster and on
 **Be aware that running more than one of these multi-container environments on one host may require 
 changing the port mapping to be changed to avoid conflicts on the host machine.**
 
-Warning: Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).
+> **Warning:** Support for Cassandra 3.11 is considered deprecated and will be removed in the Stargate v3 release: [details](https://github.com/stargate/stargate/discussions/2242).

--- a/examples/cassandra-4.0/README.md
+++ b/examples/cassandra-4.0/README.md
@@ -1,3 +1,5 @@
+# Docker Compose scripts for Stargate with Cassandra 4.0
+
 Three files to use docker-compose to start a small Cassandra 4.0 cluster and one Stargate node:
 
 * docker-compose.yaml: File that contains all parameters for starting multi-container environment.

--- a/examples/dse-6.8/README.md
+++ b/examples/dse-6.8/README.md
@@ -1,3 +1,5 @@
+# Docker Compose scripts for Stargate with DSE 6.8
+
 Three files to use docker-compose to start a small DataStax Enterprise 6.8 cluster and one Stargate node:
 
 * docker-compose.yaml: File that contains all parameters for starting multi-container environment.


### PR DESCRIPTION
Update documentation of Docker images and scripts to note deprecation of Cassandra 3.11 as a supported backend

**Which issue(s) this PR fixes**:
Part of https://github.com/stargate/stargate/issues/2254 

**Checklist**
- [ ] Changes manually tested
- [ ] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed: [DataStax CLA](https://cla.datastax.com/)
